### PR TITLE
Specify main entry of the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tokenize",
     "regex"
   ],
+  "main": "index.js",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
The `main` entry in the `package.json` is used by `webjar-locator` to build the RequireJS configuration for this project.