### PR TITLE
Set main.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "js-tokens",
   "version": "2.0.0",
   "author": "Simon Lydell",
+  "main": "index.js",
   "license": "MIT",
   "description": "A regex that tokenizes JavaScript.",
   "keywords": [
@@ -14,6 +15,7 @@
   "files": [
     "index.js"
   ],
+  
   "repository": "lydell/js-tokens",
   "scripts": {
     "test": "mocha --ui tdd",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "files": [
     "index.js"
   ],
-  
   "repository": "lydell/js-tokens",
   "scripts": {
     "test": "mocha --ui tdd",


### PR DESCRIPTION
When using Webjar and webjar-locator, the main attribute in the package.json file is required to be able to provide the RequireJS configuration.