### PR TITLE
Fix TypeScript index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,14 +22,15 @@ export declare type JSXToken =
   | { type: "JSXPunctuator"; value: string }
   | { type: "JSXInvalid"; value: string };
 
-export default function jsTokens(
+declare function jsTokens(
   input: string,
   options: { jsx: true }
 ): Iterable<Token | JSXToken>;
 
-export default function jsTokens(
+declare function jsTokens(
   input: string,
   options?: { jsx?: boolean }
 ): Iterable<Token>;
 
-export default function jsTokens(input: string): Iterable<Token>;
+// @ts-expect-error TypeScript complains about _both_ exporting types _and_ using `export =` but it seems to work fine in practice.
+export = jsTokens;


### PR DESCRIPTION
`export default` is apparently wrong for what we’re doing. `export =` is the correct one. Source: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/4706e9a84892be17888bb01a4d85c0bfed3230c2/docs/problems/FalseExportDefault.md

I’ve tested this with both `require` and `import` in both TS and JS files, with different `"module"` and `"moduleResolution"` settings, and it seems to work perfectly.

With this commit, it is now possible to do:

    const jsTokens = require("js-tokens")

in an `@ts-check`ed JS file without errors – no errors at compile time, and no errors at runtime.

**Note:** This change requires `"esModuleInterop": true`. Is it a breaking change? No. Previously, `tsc` _might_ succeed (depending on your config) event with `"esModuleInterop": false`, but at runtime you get this error:

```
TypeError: (0 , js_tokens_1.default) is not a function
```

Also note that `tsc --init` gives you `"esModuleInterop": true` (at least nowadays).