### PR TITLE
Support very long tokens where possible

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -12,13 +12,13 @@ RegularExpressionLiteral = ///
   (?:
     \[
     (?:
-      (?![ \] \\ ]).
+      [^ \] \\ \n \r \u2028 \u2029 ]+
       |
       \\.
     )*
     \]
     |
-    (?![ / \\ ]).
+    [^ / \\ \n \r \u2028 \u2029 ]+
     |
     \\.
   )*
@@ -61,7 +61,7 @@ Identifier = ///
   (\x23?)
   (?=[ $ _ \p{ID_Start} \\ ])
   (?:
-    [ $ _ \u200C \u200D \p{ID_Continue} ]
+    [ $ _ \u200C \u200D \p{ID_Continue} ]+
     |
     \\u[ \d a-f A-F ]{4}
     |
@@ -72,7 +72,9 @@ Identifier = ///
 StringLiteral = ///
   ([ ' " ])
   (?:
-    (?! \1 )[^ \\ \n \r ]
+    [^ ' " \\ \n \r ]+
+    |
+    (?! \1 )[ ' " ]
     |
     \\(?: \r\n | [^] )
   )*
@@ -112,7 +114,7 @@ NumericLiteral = ///
 Template = ///
   [ ` } ]
   (?:
-    [^ ` \\ $ ]
+    [^ ` \\ $ ]+
     |
     \\[^]
     |
@@ -134,7 +136,7 @@ LineTerminatorSequence = ///
 MultiLineComment = ///
   /\*
   (?:
-    [^*]
+    [^*]+
     |
     \*(?!/)
   )*
@@ -159,7 +161,9 @@ JSXIdentifier = ///
 JSXString = ///
   ([ ' " ])
   (?:
-    (?! \1 )[^]
+    [^ ' "]+
+    |
+    (?! \1 )[ ' " ]
   )*
   (\1)?
 ///y

--- a/test/very-long-tokens.test.js
+++ b/test/very-long-tokens.test.js
@@ -49,6 +49,23 @@ describe("Very long tokens", () => {
     test("double quote", () => {
       expect(run(`"${"a".repeat(LARGE)}"`)).toBe("StringLiteral");
     });
+
+    test("string with both large repetitions and escapes", () => {
+      const content = `\\"${"a".repeat(LARGE)}\\\\'\\"\\n`.repeat(10);
+      expect(run(`"${content}"`)).toBe("StringLiteral");
+    });
+
+    test("a string with a very large number of lines with \\n escapes", () => {
+      // Using `LARGE` results in `RangeError: Invalid string length` here.
+      const content = `${"a".repeat(100)}\\n`.repeat(1e6);
+      expect(run(`"${content}"`)).toBe("StringLiteral");
+    });
+
+    test("a string with a very large number of lines with actual escaped newlines", () => {
+      // Using `LARGE` results in `RangeError: Invalid string length` here.
+      const content = `${"a".repeat(100)}\\\n`.repeat(1e6);
+      expect(run(`"${content}"`)).toBe("StringLiteral");
+    });
   });
 
   describe("Template", () => {

--- a/test/very-long-tokens.test.js
+++ b/test/very-long-tokens.test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+const jsTokens = require("../build/index");
+
+function run(input) {
+  const types = Array.from(jsTokens(input), (token) => token.type);
+  expect(types).toHaveLength(1);
+  return types[0];
+}
+
+const LARGE = 1e7;
+
+// See https://github.com/lydell/js-tokens/issues/42
+// The regex engine can throw `Maximum call stack size exceeded` when
+// the input is too long for certain regex features. At the time of writing,
+// `(?:a|b)+` threw an error, while `[ab]+` did not. js-tokens uses alternation
+// a lot to match things like “ordinary content OR escape”. The workaround is to
+// add an unnecessary-looking `+` _inside_ the alternation (for “ordinary content”)
+// to optimize the common case.
+
+describe("Very long tokens", () => {
+  describe("RegularExpressionLiteral", () => {
+    test("basic", () => {
+      expect(run(`/${"a".repeat(LARGE)}/`)).toBe("RegularExpressionLiteral");
+    });
+
+    test("character class", () => {
+      expect(run(`/[${"a".repeat(LARGE)}]/`)).toBe("RegularExpressionLiteral");
+    });
+
+    test("flags", () => {
+      expect(run(`/a/${"g".repeat(LARGE)}`)).toBe("RegularExpressionLiteral");
+    });
+  });
+
+  test("IdentifierName", () => {
+    expect(run("a".repeat(LARGE))).toBe("IdentifierName");
+  });
+
+  test("PrivateIdentifier", () => {
+    expect(run(`#${"a".repeat(LARGE)}`)).toBe("PrivateIdentifier");
+  });
+
+  describe("StringLiteral", () => {
+    test("single quote", () => {
+      expect(run(`'${"a".repeat(LARGE)}'`)).toBe("StringLiteral");
+    });
+
+    test("double quote", () => {
+      expect(run(`"${"a".repeat(LARGE)}"`)).toBe("StringLiteral");
+    });
+  });
+
+  describe("Template", () => {
+    test("NoSubstitutionTemplate", () => {
+      expect(run(`\`${"a".repeat(LARGE)}\``)).toBe("NoSubstitutionTemplate");
+    });
+
+    test("TemplateHead + TemplateMiddle + TemplateTail", () => {
+      expect(
+        Array.from(
+          jsTokens(
+            `\`${"a".repeat(LARGE)}\${0}${"a".repeat(LARGE)}\${0}${"a".repeat(
+              LARGE
+            )}\``
+          ),
+
+          (token) => token.type
+        )
+      ).toMatchInlineSnapshot(`
+        [
+          "TemplateHead",
+          "NumericLiteral",
+          "TemplateMiddle",
+          "NumericLiteral",
+          "TemplateTail",
+        ]
+      `);
+    });
+  });
+
+  test("WhiteSpace", () => {
+    expect(run(" ".repeat(LARGE))).toBe("WhiteSpace");
+  });
+
+  test("MultiLineComment", () => {
+    expect(run(`/*${"a".repeat(LARGE)}*/`)).toBe("MultiLineComment");
+  });
+
+  test("SingleLineComment", () => {
+    expect(run(`//${"a".repeat(LARGE)}`)).toBe("SingleLineComment");
+  });
+
+  test("JSX", () => {
+    expect(
+      Array.from(
+        jsTokens(
+          `<${"a".repeat(LARGE)} ${"a".repeat(LARGE)}="${"a".repeat(
+            LARGE
+          )}">${"a".repeat(LARGE)}`,
+          { jsx: true }
+        ),
+        (token) => token.type
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        "JSXPunctuator",
+        "JSXIdentifier",
+        "WhiteSpace",
+        "JSXIdentifier",
+        "JSXPunctuator",
+        "JSXString",
+        "JSXPunctuator",
+        "JSXText",
+      ]
+    `);
+  });
+});

--- a/test/very-long-tokens.test.js
+++ b/test/very-long-tokens.test.js
@@ -68,6 +68,22 @@ describe("Very long tokens", () => {
     });
   });
 
+  test("NumericLiteral", () => {
+    // We don’t support extremely long literals for `NumericLiteral`, because
+    // that regex is already complicated enough and no real (even generated)
+    // code should end up with such long literals, since JavaScript does not
+    // have that amount of number precision anyway.
+    // `eval(`2${"0".repeat(308)}`)` gives `Infinity`, and that’s not even close
+    // to getting a `Maximum call stack size exceeded`. And you can’t have that
+    // many decimals either.
+    // eslint-disable-next-line no-loss-of-precision
+    expect(2e308).toBe(Infinity);
+    expect(run(`2${"0".repeat(308)}`)).toBe("NumericLiteral");
+    expect(() =>
+      run(`${"1".repeat(LARGE)}`)
+    ).toThrowErrorMatchingInlineSnapshot(`"Maximum call stack size exceeded"`);
+  });
+
   describe("Template", () => {
     test("NoSubstitutionTemplate", () => {
       expect(run(`\`${"a".repeat(LARGE)}\``)).toBe("NoSubstitutionTemplate");

--- a/test/very-long-tokens.test.js
+++ b/test/very-long-tokens.test.js
@@ -133,3 +133,15 @@ describe("Very long tokens", () => {
     `);
   });
 });
+
+describe("README.md examples", () => {
+  test("success", () => {
+    expect(run(`"${"a".repeat(LARGE)}"`)).toBe("StringLiteral");
+  });
+
+  test("failure", () => {
+    expect(() =>
+      run(`"${"\\n".repeat(LARGE)}"`)
+    ).toThrowErrorMatchingInlineSnapshot(`"Maximum call stack size exceeded"`);
+  });
+});


### PR DESCRIPTION
Closes #42.

I’ve tested also tested it manually with https://raw.githubusercontent.com/sapphi-red-repros/js-tokens-maximum-call-stack-size-exceeded-repro/25c76fb038d9e041c980d8df0e445ac14f3ffb26/input.js.
