### PR TITLE
Increase timeout for test that times out on Windows sometimes

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,7 +101,7 @@ describe("jsTokens", () => {
     for (let c = 0; c <= 0xffff; c++) {
       expect(() => jsTokens(String.fromCharCode(c))).not.toThrow();
     }
-  });
+  }, 10000);
 });
 
 describe("Token", () => {


### PR DESCRIPTION
For example: https://github.com/lydell/js-tokens/actions/runs/14270735240/job/40003142240

```
 FAIL  test/index.test.js > jsTokens > succeeds for any single character
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
```